### PR TITLE
feat: add Telegram link button to join Alpha Group in payment success page

### DIFF
--- a/src/app/payment/success/page.tsx
+++ b/src/app/payment/success/page.tsx
@@ -9,9 +9,11 @@ import { BiCheckCircle } from "react-icons/bi";
 import { getAuthTokenFromStorage } from "@/lib/auth";
 import { MdCancel } from "react-icons/md";
 import { ApiTransaction } from "@/lib/types";
+import { initUtils } from "@telegram-apps/sdk-react";
 
 export default function PaymentSuccessPage() {
     const router = useRouter();
+    const utils = initUtils();
     const { setSubscription } = useStore();
     const [isProcessing, setIsProcessing] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -198,6 +200,18 @@ export default function PaymentSuccessPage() {
                     )}
 
                     <div className="space-y-3">
+                        {process.env.NEXT_PUBLIC_TELEGRAM_ALPHA_GROUP_LINK && (
+                            <Button
+                                onClick={() =>
+                                    utils.openTelegramLink(
+                                        process.env.NEXT_PUBLIC_TELEGRAM_ALPHA_GROUP_LINK!
+                                    )
+                                }
+                                className="w-full bg-green-600 hover:bg-green-700"
+                            >
+                                Join Alpha Group
+                            </Button>
+                        )}
                         <Button
                             onClick={() => router.push("/dashboard")}
                             className="w-full bg-orange-600 hover:bg-orange-700"


### PR DESCRIPTION
<img width="702" height="1357" alt="image" src="https://github.com/user-attachments/assets/db3e9d0d-7db9-4ecf-b414-a7e7ff8d12dc" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Join Alpha Group" green button to the payment success page, allowing users to join a Telegram group directly from the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->