### PR TITLE
feat: add skeleton loading placeholders

### DIFF
--- a/src/app/dashboard/history/page.tsx
+++ b/src/app/dashboard/history/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { getAuthTokenFromStorage } from "@/lib/auth";
 import type { ApiTransaction } from "@/lib/types";
 import { cn } from "@/lib/cn";
-import LoadingPage from "@/components/LoadingPage";
+import ListItemSkeleton from "@/components/skeletons/ListItemSkeleton";
 import { formatDate, formatSatoshis } from "@/lib/formatters";
 import { useQuery } from "@tanstack/react-query";
 
@@ -132,10 +132,7 @@ export default function HistoryPage() {
         }
     };
 
-    // Show loading state
-    if (isLoading) {
-        return <LoadingPage />;
-    }
+    const loading = isLoading;
 
     return (
         <main className="pb-20">
@@ -166,7 +163,7 @@ export default function HistoryPage() {
             </div>
 
             {/* Error State */}
-            {errorMessage && (
+            {errorMessage && !loading && (
                 <div className="mb-6 rounded-xl border border-red-500/30 bg-zinc-900/50 p-4 backdrop-blur-sm">
                     <h3 className="mb-2 font-medium text-red-400">Failed to Load Transactions</h3>
                     <p className="mb-4 text-sm text-gray-400">{errorMessage}</p>
@@ -180,7 +177,7 @@ export default function HistoryPage() {
             )}
 
             {/* No Auth Token */}
-            {!authToken && (
+            {!authToken && !loading && (
                 <div className="py-8 text-center text-gray-400">
                     <p className="mb-2">Please authenticate to view transactions</p>
                     <p className="text-sm text-gray-500">
@@ -191,6 +188,13 @@ export default function HistoryPage() {
 
             {/* Transactions List */}
             {authToken && !errorMessage && (
+                loading ? (
+                    <div className="space-y-2">
+                        {Array.from({ length: 5 }).map((_, i) => (
+                            <ListItemSkeleton key={i} />
+                        ))}
+                    </div>
+                ) : (
                 <div className="space-y-0">
                     {apiTransactions.length > 0 ? (
                         apiTransactions.map((transaction) => {
@@ -313,7 +317,8 @@ export default function HistoryPage() {
                         </div>
                     )}
                 </div>
-            )}
+            )
+        )}
 
             {/* Transaction Detail Modal */}
             {selectedTransaction && (

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,7 +9,8 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useBackButton, useLaunchParams } from "@telegram-apps/sdk-react";
 import { authenticateWithTelegram, getAuthTokenFromStorage, saveAuthToStorage } from "@/lib/auth";
-import LoadingPage from "@/components/LoadingPage";
+import BalanceCardSkeleton from "@/components/skeletons/BalanceCardSkeleton";
+import ChartSkeleton from "@/components/skeletons/ChartSkeleton";
 import fetchy from "@/lib/fetchy";
 import { UserExistsResponse } from "@/lib/types";
 import { toast } from "sonner";
@@ -169,9 +170,7 @@ export default function WalletPage() {
         }
     }, [summaryError]);
 
-    if (isLoading || summaryLoading) {
-        return <LoadingPage />;
-    }
+    const loading = isLoading || summaryLoading;
 
     if (authError) {
         return (
@@ -249,6 +248,9 @@ export default function WalletPage() {
                 </div>
 
                 {/* Balance Card */}
+                {loading ? (
+                    <BalanceCardSkeleton />
+                ) : (
                 <div className="mb-8 rounded-3xl border border-gray-700 bg-gradient-to-r from-gray-600/20 to-gray-500/20 p-6">
                     <div className="mb-4 flex items-center justify-between">
                         <div>
@@ -550,9 +552,14 @@ export default function WalletPage() {
                         ))}
                     </div> */}
                 </div>
+                )}
 
                 {/* DCA Chart Section */}
-                <DCAChart authToken={authToken} avgBtcPrice={summary?.dca.avg_btc_price} />
+                {loading ? (
+                    <ChartSkeleton />
+                ) : (
+                    <DCAChart authToken={authToken} avgBtcPrice={summary?.dca.avg_btc_price} />
+                )}
             </main>
         </div>
     );

--- a/src/app/subscription/page.tsx
+++ b/src/app/subscription/page.tsx
@@ -12,7 +12,8 @@ import {
 import { useStore } from "@/lib/store";
 import type { SubscriptionPlan } from "@/lib/types";
 import { cn } from "@/lib/cn";
-import LoadingPage from "@/components/LoadingPage";
+import { LoadingSpinner } from "@/components/LoadingPage";
+import ListItemSkeleton from "@/components/skeletons/ListItemSkeleton";
 import Image from "next/image";
 import { Button, Input } from "@telegram-apps/telegram-ui";
 import { usePayHereRedirect } from "@/lib/hooks";
@@ -326,9 +327,7 @@ export default function SubscriptionPage() {
         }
     };
 
-    if (isLoading || isRegistering || packagesLoading) {
-        return <LoadingPage />;
-    }
+    const loading = isLoading || packagesLoading;
 
     if (authError || packagesError) {
         return (
@@ -350,7 +349,12 @@ export default function SubscriptionPage() {
     }
 
     return (
-        <div className="min-h-screen bg-[#202020]">
+        <div className="relative min-h-screen bg-[#202020]">
+            {isRegistering && (
+                <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/50">
+                    <LoadingSpinner />
+                </div>
+            )}
             <div className="mx-auto max-w-md">
                 {!showRegistrationForm ? (
                     // Plan Selection Screen
@@ -371,17 +375,21 @@ export default function SubscriptionPage() {
 
                         {/* Plans */}
                         <div className="mb-2 space-y-3 p-4">
-                            {packages.map((plan) => (
-                                <div
-                                    key={plan.id}
-                                    className={cn(
-                                        "flex cursor-pointer items-center justify-between rounded-xl border-2 p-3 transition-all duration-300",
-                                        selectedPlan === plan.id
-                                            ? "border-orange-500 bg-gradient-to-r from-orange-500/10 to-orange-600/10 shadow-lg shadow-orange-500/20"
-                                            : "border-gray-700 bg-gradient-to-r from-gray-800/50 to-gray-900/50 hover:border-gray-600"
-                                    )}
-                                    onClick={() => setSelectedPlan(plan.id)}
-                                >
+                            {loading
+                                ? Array.from({ length: 3 }).map((_, i) => (
+                                      <ListItemSkeleton key={i} />
+                                  ))
+                                : packages.map((plan) => (
+                                      <div
+                                          key={plan.id}
+                                          className={cn(
+                                              "flex cursor-pointer items-center justify-between rounded-xl border-2 p-3 transition-all duration-300",
+                                              selectedPlan === plan.id
+                                                  ? "border-orange-500 bg-gradient-to-r from-orange-500/10 to-orange-600/10 shadow-lg shadow-orange-500/20"
+                                                  : "border-gray-700 bg-gradient-to-r from-gray-800/50 to-gray-900/50 hover:border-gray-600"
+                                          )}
+                                          onClick={() => setSelectedPlan(plan.id)}
+                                      >
                                     <div className="flex items-center gap-3">
                                         <div
                                             className={cn(

--- a/src/components/skeletons/BalanceCardSkeleton.tsx
+++ b/src/components/skeletons/BalanceCardSkeleton.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+export function BalanceCardSkeleton() {
+    return (
+        <div className="mb-8 rounded-3xl border border-gray-700 bg-gradient-to-r from-gray-600/20 to-gray-500/20 p-6 animate-pulse">
+            <div className="mb-4 flex items-center justify-between">
+                <div className="h-4 w-24 rounded bg-gray-700"></div>
+                <div className="flex items-center gap-2">
+                    <div className="h-8 w-8 rounded-full bg-gray-700"></div>
+                    <div className="h-8 w-8 rounded-full bg-gray-700"></div>
+                </div>
+            </div>
+            <div className="mb-6 h-8 w-1/2 rounded bg-gray-700"></div>
+            <div className="h-40 w-full rounded-xl bg-gray-700"></div>
+        </div>
+    );
+}
+
+export default BalanceCardSkeleton;

--- a/src/components/skeletons/ChartSkeleton.tsx
+++ b/src/components/skeletons/ChartSkeleton.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+export function ChartSkeleton() {
+    return (
+        <div className="mb-6 rounded-2xl border border-gray-700 bg-gray-800/50 p-6 animate-pulse">
+            <div className="mb-4 h-5 w-1/3 rounded bg-gray-700"></div>
+            <div className="h-48 w-full rounded bg-gray-700"></div>
+        </div>
+    );
+}
+
+export default ChartSkeleton;

--- a/src/components/skeletons/ListItemSkeleton.tsx
+++ b/src/components/skeletons/ListItemSkeleton.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+export function ListItemSkeleton() {
+    return (
+        <div className="rounded-xl border border-gray-700 p-4 animate-pulse">
+            <div className="mb-2 flex items-center justify-between">
+                <div className="h-4 w-24 rounded bg-gray-700"></div>
+                <div className="h-4 w-16 rounded bg-gray-700"></div>
+            </div>
+            <div className="h-3 w-32 rounded bg-gray-700"></div>
+        </div>
+    );
+}
+
+export default ListItemSkeleton;


### PR DESCRIPTION
## Summary
- add reusable skeleton components for balance cards, charts and lists
- display skeleton placeholders on dashboard, history and subscription pages instead of full-page loader

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892ed98c128833185b61404d40c94f0