### PR TITLE
fix: eager-load header logos

### DIFF
--- a/src/app/onboard/page.tsx
+++ b/src/app/onboard/page.tsx
@@ -124,12 +124,9 @@ export default function OnboardPage() {
                 {/* Header */}
                 <div className="mb-8 text-center">
                     <section className="flex flex-col items-center justify-center text-center">
-                        <Image
-                            src="/BDLogo_White.svg"
-                            width={130}
-                            height={130}
-                            alt="Bitcoin Deepa"
-                        />
+                        <div className="relative h-[130px] w-[130px]">
+                            <Image src="/BDLogo_White.svg" alt="Bitcoin Deepa" fill priority />
+                        </div>
                         <Title weight="2">Welcome to Bitcoin Deepa! 🇱🇰</Title>
                     </section>
                     <Subheadline className="mt-3 text-gray-300">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,7 +45,9 @@ export default function Home() {
     return (
         <main className="grid min-h-screen p-5">
             <section className="flex flex-col items-center justify-center text-center">
-                <Image src="/BDLogo_White.svg" width={160} height={160} alt="Bitcoin Deepa" />
+                <div className="relative h-[160px] w-[160px]">
+                    <Image src="/BDLogo_White.svg" alt="Bitcoin Deepa" fill priority />
+                </div>
                 <Title weight="2">Join Sri Lanka&apos;s Fastest Growing Bitcoin Community 🇱🇰</Title>
                 <UserCount />
             </section>


### PR DESCRIPTION
## Summary
- wrap logo images in fixed-size containers
- eagerly load the logo for faster visual readiness

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0f90204b4832c91791cdf47312b2e